### PR TITLE
Verify input names before running inference sessions

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -232,6 +232,7 @@ namespace OpenUtau.Core.DiffSinger
             linguisticInputs.Add(NamedOnnxValue.CreateFromTensor("word_dur",
                 new DenseTensor<Int64>(word_dur, new int[] { word_dur.Length }, false)
                 .Reshape(new int[] { 1, word_dur.Length })));
+            Onnx.VerifyInputNames(linguisticModel, linguisticInputs);
             var linguisticOutputs = linguisticModel.Run(linguisticInputs);
             Tensor<float> encoder_out = linguisticOutputs
                 .Where(o => o.Name == "encoder_out")
@@ -262,6 +263,7 @@ namespace OpenUtau.Core.DiffSinger
                 var spkEmbedTensor = speakerEmbedManager.PhraseSpeakerEmbedByPhone(speakersByPhone);
                 durationInputs.Add(NamedOnnxValue.CreateFromTensor("spk_embed", spkEmbedTensor));
             }
+            Onnx.VerifyInputNames(durationModel, durationInputs);
             var durationOutputs = durationModel.Run(durationInputs);
             List<double> durationFrames = durationOutputs.First().AsTensor<float>().Select(x=>(double)x).ToList();
             

--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -120,7 +120,8 @@ namespace OpenUtau.Core.DiffSinger
                     new DenseTensor<Int64>(ph_dur.Select(x=>(Int64)x).ToArray(), new int[] { ph_dur.Length }, false)
                     .Reshape(new int[] { 1, ph_dur.Length })));
             }
-            
+
+            Onnx.VerifyInputNames(linguisticModel, linguisticInputs);
             var linguisticOutputs = linguisticModel.Run(linguisticInputs);
             Tensor<float> encoder_out = linguisticOutputs
                 .Where(o => o.Name == "encoder_out")
@@ -258,6 +259,7 @@ namespace OpenUtau.Core.DiffSinger
                 .Reshape(new int[] { 1, note_rest.Count })));
             }
 
+            Onnx.VerifyInputNames(pitchModel, pitchInputs);
             var pitchOutputs = pitchModel.Run(pitchInputs);
             var pitch_out = pitchOutputs.First().AsTensor<float>().ToArray();
             var pitchEnd = phrase.timeAxis.MsPosToTickPos(startMs + (totalFrames - 1) * frameMs) - phrase.position;

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -247,8 +247,10 @@ namespace OpenUtau.Core.DiffSinger {
                 }
             }
 
+            var acousticModel = singer.getAcousticSession();
+            Onnx.VerifyInputNames(acousticModel, acousticInputs);
             Tensor<float> mel;
-            var acousticOutputs = singer.getAcousticSession().Run(acousticInputs);
+            var acousticOutputs = acousticModel.Run(acousticInputs);
             mel = acousticOutputs.First().AsTensor<float>().Clone();
             
             //vocoder

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -115,7 +115,8 @@ namespace OpenUtau.Core.DiffSinger{
                     new DenseTensor<Int64>(ph_dur.Select(x=>(Int64)x).ToArray(), new int[] { ph_dur.Length }, false)
                     .Reshape(new int[] { 1, ph_dur.Length })));
             }
-            
+
+            Onnx.VerifyInputNames(linguisticModel, linguisticInputs);
             var linguisticOutputs = linguisticModel.Run(linguisticInputs);
             Tensor<float> encoder_out = linguisticOutputs
                 .Where(o => o.Name == "encoder_out")
@@ -156,6 +157,7 @@ namespace OpenUtau.Core.DiffSinger{
                 var spkEmbedTensor = speakerEmbedManager.PhraseSpeakerEmbedByFrame(phrase, ph_dur, frameMs, totalFrames, headFrames, tailFrames);
                 varianceInputs.Add(NamedOnnxValue.CreateFromTensor("spk_embed", spkEmbedTensor));
             }
+            Onnx.VerifyInputNames(varianceModel, varianceInputs);
             var varianceOutputs = varianceModel.Run(varianceInputs);
             Tensor<float> energy_pred = varianceOutputs
                 .Where(o => o.Name == "energy_pred")

--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -84,5 +84,24 @@ namespace OpenUtau.Core {
         public static InferenceSession getInferenceSession(string modelPath) {
             return new InferenceSession(modelPath,getOnnxSessionOptions());
         }
+
+        public static void VerifyInputNames(InferenceSession session, IEnumerable<NamedOnnxValue> inputs) {
+            var sessionInputNames = session.InputNames.ToHashSet();
+            var givenInputNames = inputs.Select(v => v.Name).ToHashSet();
+            var missing = sessionInputNames
+                .Except(givenInputNames)
+                .OrderBy(s => s, StringComparer.InvariantCulture)
+                .ToArray();
+            if (missing.Length > 0) {
+                throw new ArgumentException("Missing input(s) for the inference session: " + string.Join(", ", missing));
+            }
+            var unexpected = givenInputNames
+                .Except(sessionInputNames)
+                .OrderBy(s => s, StringComparer.InvariantCulture)
+                .ToArray();
+            if (unexpected.Length > 0) {
+                throw new ArgumentException("Unexpected input(s) for the inference session: " + string.Join(", ", unexpected));
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds verification steps before calling `Run()` on ONNX inference sessions. This can help produce more readable error messages in case the given and required input names mismatch.