### PR TITLE
When saving oto.ini, always include alias in oto lines even if the filename and alias are same

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -500,9 +500,7 @@ namespace OpenUtau.Classic {
                     }
                     writer.Write(oto.Wav);
                     writer.Write('=');
-                    if (oto.Alias != RemoveExtension(oto.Wav)) {
-                        writer.Write(oto.Alias);
-                    }
+                    writer.Write(oto.Alias);
                     writer.Write(',');
                     if (oto.Offset != 0) {
                         writer.Write(oto.Offset);


### PR DESCRIPTION
An user reports that Ameya UTAU can't recognize oto.ini lines with blank alias